### PR TITLE
Tooltip container fix

### DIFF
--- a/marklogic-data-hub-central/ui/src/components/steps/steps.scss
+++ b/marklogic-data-hub-central/ui/src/components/steps/steps.scss
@@ -7,12 +7,6 @@
     margin-left: 430px;
 }
 
-#basicTooltip {
+#basicTooltip, #advTooltip {
     max-width: 100%;
-    font-size: 10px;
-  }
-
-#advTooltip {
-    max-width: 100%;
-    font-size: 10px;
-  }
+}

--- a/marklogic-data-hub-central/ui/src/components/steps/steps.tsx
+++ b/marklogic-data-hub-central/ui/src/components/steps/steps.tsx
@@ -176,7 +176,7 @@ const Steps: React.FC<Props> = (props) => {
     maskClosable={false}
     destroyOnClose={true}
   >
-    <div aria-label="steps" className={styles.stepsContainer}>
+    <div aria-label="steps" id="stepSettings" className={styles.stepsContainer}>
       <header>
         <div className={styles.title}>{getTitle()}</div>
       </header>
@@ -186,14 +186,24 @@ const Steps: React.FC<Props> = (props) => {
         <div className={styles.tabs}>
           <Tabs activeKey={currentTab} defaultActiveKey={DEFAULT_TAB} size={"large"} onTabClick={handleTabChange} animated={false} tabBarGutter={10}>
           <TabPane tab={(
-            <MLTooltip id="basicTooltip" style={ {wordBreak: "break-all"} }
-            title={(!isValid && currentTab !== "1") ? ErrorTooltips.disabledTab : null} placement={"topRight"}>Basic</MLTooltip>
+            <MLTooltip 
+              id="basicTooltip" 
+              style={ {wordBreak: "break-all"} }
+              title={(!isValid && currentTab !== "1") ? ErrorTooltips.disabledTab : null} 
+              placement={"bottom"}
+              getPopupContainer={() => document.getElementById("stepSettings") || document.body}
+            >Basic</MLTooltip>
           )} key="1" disabled={!isValid && currentTab !== "1"}>
               {getCreateEditStep(props.activityType)}
             </TabPane>
             <TabPane tab={(
-            <MLTooltip id="advTooltip" style={ {wordBreak: "break-all"} }
-            title={(!isValid && currentTab !== "2") ? ErrorTooltips.disabledTab : null} placement={"topRight"}>Advanced</MLTooltip>
+            <MLTooltip 
+              id="advTooltip" 
+              style={ {wordBreak: "break-all"} }
+              title={(!isValid && currentTab !== "2") ? ErrorTooltips.disabledTab : null} 
+              placement={"bottom"}
+              getPopupContainer={() => document.getElementById("stepSettings") || document.body}
+            >Advanced</MLTooltip>
           )} key="2" disabled={!isValid && currentTab !== "2"}> 
              <AdvancedSettings
                 tabKey="2"


### PR DESCRIPTION
Apply the getPopupContainer property to the tooltip to control where the tooltip HTML is placed in the DOM. This lets us place it outside the tab (so the tooltip is not cropped) but inside the modal dialog so that the tooltip will scroll as the modal scrolls.

When placed just inside the modal dialog, we can then set the placement property to "bottom".

There are a few other places in the app where we've had to do this for certain Ant Design components, for example: 

https://github.com/marklogic/marklogic-data-hub/blob/develop/marklogic-data-hub-central/ui/src/components/entities/mapping/source-entity-map/source-to-entity-map.tsx#L610